### PR TITLE
correcting_measurement_units

### DIFF
--- a/adafruit_l3gd20.py
+++ b/adafruit_l3gd20.py
@@ -35,6 +35,7 @@ __version__ = "0.0.0-auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_l3gd20.git"
 
 
+from math import radians
 from micropython import const
 from adafruit_register.i2c_struct import Struct
 
@@ -195,10 +196,10 @@ class L3GD20:
     def gyro(self):
         """
         x, y, z angular momentum tuple floats, rescaled appropriately for
-        range selected
+        range selected in rad/s
         """
         raw = self.gyro_raw
-        return tuple(self.scale * v for v in raw)
+        return tuple(radians(self.scale * v) for v in raw)
 
 
 class L3GD20_I2C(L3GD20):
@@ -364,7 +365,7 @@ class L3GD20_SPI(L3GD20):
 
     @property
     def gyro_raw(self):
-        """Gives the dynamic rate raw gyro readings, in units of DPS."""
+        """Gives the dynamic rate raw gyro readings, in units rad/s."""
         buffer = self._spi_bytearray6
         self.read_bytes(_L3GD20_REGISTER_OUT_X_L_X40, buffer)
-        return unpack("<hhh", buffer)
+        return tuple(radians(x) for x in unpack("<hhh", buffer))

--- a/adafruit_l3gd20.py
+++ b/adafruit_l3gd20.py
@@ -364,7 +364,7 @@ class L3GD20_SPI(L3GD20):
 
     @property
     def gyro_raw(self):
-        """Gives the raw gyro readings, in units of rad/s."""
+        """Gives the dynamic rate raw gyro readings, in units of DPS."""
         buffer = self._spi_bytearray6
         self.read_bytes(_L3GD20_REGISTER_OUT_X_L_X40, buffer)
         return unpack("<hhh", buffer)

--- a/examples/l3gd20_simpletest.py
+++ b/examples/l3gd20_simpletest.py
@@ -1,7 +1,6 @@
 # SPDX-FileCopyrightText: 2021 ladyada for Adafruit Industries
 # SPDX-License-Identifier: MIT
 
-import math
 import time
 import board
 import adafruit_l3gd20
@@ -39,14 +38,6 @@ SENSOR = adafruit_l3gd20.L3GD20_I2C(I2C)
 # )
 
 while True:
-    value_DPS = SENSOR.gyro
-    value_rds = (
-        SENSOR.gyro[0] * math.pi / 180,
-        SENSOR.gyro[1] * math.pi / 180,
-        SENSOR.gyro[2] * math.pi / 180,
-    )
-    print("Dynamic Range (DPS): {}".format(value_DPS))
-    print("-------------------------------------------------------------")
-    print("Angular Velocity (rad/s) {}".format(value_rds))
+    print("Angular Velocity (rad/s): {}".format(SENSOR.gyro))
     print()
     time.sleep(1)

--- a/examples/l3gd20_simpletest.py
+++ b/examples/l3gd20_simpletest.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: 2021 ladyada for Adafruit Industries
 # SPDX-License-Identifier: MIT
 
+import math
 import time
 import board
 import adafruit_l3gd20
@@ -38,6 +39,14 @@ SENSOR = adafruit_l3gd20.L3GD20_I2C(I2C)
 # )
 
 while True:
-    print("Angular Momentum (rad/s): {}".format(SENSOR.gyro))
+    value_DPS = SENSOR.gyro
+    value_rds = (
+        SENSOR.gyro[0] * math.pi / 180,
+        SENSOR.gyro[1] * math.pi / 180,
+        SENSOR.gyro[2] * math.pi / 180,
+    )
+    print("Dynamic Range (DPS): {}".format(value_DPS))
+    print("-------------------------------------------------------------")
+    print("Angular Velocity (rad/s) {}".format(value_rds))
     print()
     time.sleep(1)


### PR DESCRIPTION
solves #20 .
The design guide is correct. However the sensor gives DPS or degrees per second as an output measure
This is stated in the Datasheet
![image](https://user-images.githubusercontent.com/34255413/117527033-dc3ef200-af96-11eb-994f-23a78ec8e496.png)
also in the learning guide
https://learn.adafruit.com/comparing-gyroscope-datasheets

Changes were made in the example and also in the library.

The DPS measure was confirmed changing the `rng` parameter. and tested in 
```python
Adafruit CircuitPython 6.2.0 on 2021-04-05; Adafruit Feather RP2040 with rp2040
```